### PR TITLE
fixes for golang

### DIFF
--- a/.libshrc_example
+++ b/.libshrc_example
@@ -4,30 +4,72 @@
 # Variables used by LIBSH
 #
 
-# enable debuging to a file of $LIBSH_HOME/debug.log
-# export LIBSH_DEBUG=t
-
-# define your parent directory of all code
-# this is used by the "git_clone" function to
-# organize your repos by $domain/$org/$project
-# export LIBSH_SRC_DIR=$HOME/src
+############
+# Vault    #
+# Settings #
+############
 
 # should we try to login with vault_login?
 # export LIBSH_USE_VAULT_LOGIN=t
 
+
+############
+# RVM      #
+# Settings #
+############
+
 # rvm can be bloated sometimes
 # to disable per env, set or unset
 # export LIBSH_ENABLE_RVM=t
+
+
+############
+# Shell    #
+# Settings #
+############
 
 # what directories do you want to seach for by name?
 # this makes for having to just type the directory
 # into the shell prompt and it will find the first match
 # export LIBSH_CDPATH=$HOME/src:$HOME/github.com:$HOME/company.com
 
+############
+# Git/Code #
+# Settings #
+############
+
 # define a git template that you want to use for your
 # commit messages
 # export ENABLE_GIT_COMMIT_TEMPLATE=$HOME/src/dotfiles/git/commit-msg-template
 
+# define your parent directory of all code
+# this is used by the "git_clone" function to
+# organize your repos by $domain/$org/$project
+# export LIBSH_SRC_DIR=$HOME/src
+
+
+##########
+#        #
+# GOLang #
+#        #
+##########
+
+# GoEnv
+#
+# This allows you to select versions of GoLangs installed
+# on your system. Some people like this and its best to
+# let the tool take over setting paths. To stop this,
+# comment out the following line:
+export LIBSH_GOENV_MGMT_PATH=true
+
+
+############
+# LibSh    #
+# Settings #
+############
+
+# enable debuging to a file of $LIBSH_HOME/debug.log
+# export LIBSH_DEBUG=t
 
 # Select functions to load
 #

--- a/go.env.sh
+++ b/go.env.sh
@@ -1,11 +1,11 @@
 # GOENV
 [ -d $HOME/.goenv ] && export GOENV_ROOT="$HOME/.goenv"
 [ -d $HOME/.goenv ] && libsh__add_path "pre" "$GOENV_ROOT/bin"
-[ -d $GOPATH/bin ] || mkdir $GOPATH/bin
+# [ -d $GOPATH/bin ] || mkdir $GOPATH/bin
 
 # let GOENV manage paths
-[ -d $HOME/.goenv ] && libsh__add_path "pre" "$GOROOT/bin"
-[ -d $HOME/.goenv ] && libsh__add_path "post" "$GOPATH/bin"
+# [ -d $HOME/.goenv ] && libsh__add_path "pre" "$GOROOT/bin"
+# [ -d $HOME/.goenv ] && libsh__add_path "post" "$GOPATH/bin"
 
 # GOPATH
 ## this will not conflict with goenv because the destination for 

--- a/go.sh
+++ b/go.sh
@@ -1,5 +1,9 @@
 # if you have .goenv installed, init
+#[ -d $HOME/.goenv ] && export GOENV_ROOT="$HOME/.goenv"
+#[ -d $HOME/.goenv ] && libsh__add_path "pre" "$GOENV_ROOT/bin"
 [ -d $HOME/.goenv ] && eval "$(goenv init -)"
+[ ! -z $LIBSH_GOENV_MGMT_PATH ] && libsh__add_path "pre" "$GOROOT/bin"
+[ ! -z $LIBSH_GOENV_MGMT_PATH ] && libsh__add_path "post" "$GOPATH/bin"
 
 go_validate_env() {
     command -v git > /dev/null


### PR DESCRIPTION
These changes account for using goenv and how the paths
are set. A new option has been added for making the paths
be managed by GOENV or not managed. Its better to let the
tool manage them, but if you comment out the settings in
.libshrc.sh you can break free.